### PR TITLE
⬆️ react-router 8

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
       react-router:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-rx:
         specifier: ^4.2.3
         version: 4.2.3(react@19.2.8)(rxjs@7.8.2)
@@ -2741,9 +2741,8 @@ packages:
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -3867,12 +3866,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -4018,9 +4017,6 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7667,7 +7663,7 @@ snapshots:
 
   cookie-es@1.2.3: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   core-util-is@1.0.3: {}
 
@@ -8922,11 +8918,10 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      cookie: 1.1.1
+      cookie-es: 3.1.1
       react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
@@ -9112,8 +9107,6 @@ snapshots:
   semver@7.8.5: {}
 
   set-blocking@2.0.0: {}
-
-  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,11 +14,19 @@ allowBuilds:
 # provides some buffer time for the package maintainer / wider community to detect and publicise malicious package versions
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
+  # First-party packages published by this org — the buffer exists to catch a compromised
+  # third-party publisher, which doesn't apply here. Remove only if @kheopskit stops being ours.
   - "@kheopskit/core"
   - "@kheopskit/react"
+  # Core dependency, pinned to exact versions and tracked closely (descriptors are regenerated
+  # against it). Kept so an upstream hotfix can be installed the day it ships. Remove if we're
+  # willing to sit 3 days behind on papi releases.
   - "polkadot-api"
   - "@polkadot-api/*"
-  - "@types/node"
+  # TEMPORARY — GHSA-qwww-vcr4-c8h2 (high) is only patched in react-router 8.3.0, published
+  # 2026-07-22T15:04Z, i.e. inside the window. Remove on/after 2026-07-25T15:04Z, once the
+  # locked version has aged past minimumReleaseAge on its own.
+  - "react-router"
 
 # moved from package.json "pnpm" field (pnpm 11 no longer reads it, see https://pnpm.io/settings)
 overrides:

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,7 @@
 		"polkadot-api": "2.2.1",
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",
-		"react-router": "^7.18.1",
+		"react-router": "^8.3.0",
 		"react-rx": "^4.2.3",
 		"react-toastify": "^11.1.0",
 		"rxjs": "^7.8.2",


### PR DESCRIPTION
Bumps react-router 7.18.1 → 8.3.0. No code changes required — the app is data-mode only (`createHashRouter` + `RouterProvider` from `react-router/dom`), no `react-router-dom` dep, no loaders/actions/`useMatches`.

Fixes GHSA-qwww-vcr4-c8h2 (high, RSC-mode CSRF bypass) — patched only in 8.3.0. `pnpm audit --prod` goes from 1 high + 1 low to 1 low (the known esbuild dev-server one, already documented as not applicable).

8.3.0 was published inside the 3-day `minimumReleaseAge` window, so react-router is temporarily added to `minimumReleaseAgeExclude` with a note to remove it after 2026-07-25T15:04Z. Took the opportunity to document why each remaining entry is there and when it can be dropped; `@types/node` removed (nothing needs it).

Verified: biome ci, knip, 161 tests, typecheck, build, plus a browser pass against live chain data — root redirect, nav links, page titles, pool deep links (`#/polkadot/pools/0` → DOT/USDt LP), alternate relay. Behaviour matches a v7 baseline built from main.