### PR TITLE
🐛 fix redirect loop on unknown routes

### DIFF
--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createHashRouter, Navigate } from "react-router";
+import { createHashRouter, Navigate, useParams } from "react-router";
 
 import { CreateLiquidityPoolPage } from "./create-pool";
 import { ErrorBoundaryPage } from "./error";
@@ -8,6 +8,14 @@ import { PortfolioPage } from "./portfolio";
 import { AppWithRelay } from "./providers/AppWithRelay";
 import { SwapPage } from "./swap";
 import { TransferPage } from "./transfer";
+
+// relative targets resolve against the matched path, which for the catch-all route
+// includes the unmatched segments - it would redirect to `<unknown path>/swap`, match
+// the catch-all again, and loop until the URL is unusable
+const RedirectToSwap = () => {
+	const { relayId } = useParams();
+	return <Navigate to={`/${relayId}/swap`} replace />;
+};
 
 export const router = createHashRouter([
 	{
@@ -41,11 +49,11 @@ export const router = createHashRouter([
 			},
 			{
 				path: "",
-				element: <Navigate to="swap" replace />,
+				element: <RedirectToSwap />,
 			},
 			{
 				path: "*",
-				element: <Navigate to="swap" replace />,
+				element: <RedirectToSwap />,
 			},
 		],
 	},


### PR DESCRIPTION
Any unknown path under a relay sent the app into an infinite redirect loop instead of falling back to swap.

The catch-all route `{ path: "*", element: <Navigate to="swap" replace /> }` used a relative target. Relative targets resolve against the matched path, which for a catch-all includes the unmatched segments — so `#/polkadot/nope` redirected to `#/polkadot/nope/swap`, which matched the catch-all again, and so on. The URL grew to ~200 `/swap` segments and the app never rendered.

Replaced both fallbacks with a small component that builds an absolute path from the `relayId` param.

Verified in a browser against a production build:
- `#/polkadot/nope` → `#/polkadot/swap`
- `#/polkadot/a/b/c` → `#/polkadot/swap`
- `#/polkadot` → `#/polkadot/swap`
- `#/kusama/nope` → `#/kusama/swap` (relay preserved)
- `#/foo/bar` → `#/polkadot/swap` (invalid relay, unchanged behaviour)

Pre-existing on main, unrelated to #82 — reproduced identically on react-router 7 and 8.