### PR TITLE
🐛 fix dev server typecheck overlay

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 		react(),
 		svgr(),
 		checker({
-			typescript: true,
+			typescript: { tsconfigPath: "tsconfig.app.json" },
 			biome: true,
 			overlay: { initialIsOpen: "error" },
 		}),


### PR DESCRIPTION
The dev-server TypeScript check has been silently checking nothing.

`checker({ typescript: true })` resolves `web/tsconfig.json`, which is a solution-style stub (`"files": []` plus references). With no files in the program the checker always reported `[TypeScript] Found 0 errors`, even with genuine type errors in `src` that `pnpm typecheck` fails on. So the overlay never fired and dev-time type feedback came only from the IDE.

Points the checker at `tsconfig.app.json`, the project that actually covers `src`.

Verified by adding a deliberate type error: before the fix the dev server reported `Found 0 errors`; after it reports `Found 1 error. Watching for file changes.`, and returns to `Found 0 errors` once removed.

Pre-existing on main and independent of #84 — the same dead check happens on TypeScript 6 and 7.