### PR TITLE
⚡ speed up CI

### DIFF
--- a/.github/workflows/fetch-tokens.yaml
+++ b/.github/workflows/fetch-tokens.yaml
@@ -18,16 +18,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: "package.json"
           cache: "pnpm"
+
+      # see pull_request.yaml — papi's postinstall codegen dominates the install step otherwise
+      - name: Restore papi descriptors
+        uses: actions/cache@v6
+        with:
+          path: .papi/descriptors
+          key: papi-${{ runner.os }}-${{ hashFiles('.papi/polkadot-api.json', '.papi/scale/**', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            papi-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,31 +12,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: "package.json"
           cache: "pnpm"
 
+      # papi runs on postinstall and generating descriptors from scratch takes ~40s, which is
+      # most of the install step. It validates restored descriptors against the codeHash in
+      # polkadot-api.json and regenerates them on mismatch, so an approximate restore is safe.
+      - name: Restore papi descriptors
+        uses: actions/cache@v6
+        with:
+          path: .papi/descriptors
+          key: papi-${{ runner.os }}-${{ hashFiles('.papi/polkadot-api.json', '.papi/scale/**', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            papi-${{ runner.os }}-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # cheapest checks first, so an obvious failure reports without waiting on the slow ones
       - name: Biome check
         run: pnpm biome ci --error-on-warnings .
+
+      - name: Typecheck
+        run: pnpm typecheck
 
       - name: Knip (unused files & dependencies)
         run: pnpm knip --include files,dependencies,devDependencies
 
       - name: Test
         run: pnpm test
-
-      - name: Typecheck
-        run: pnpm typecheck
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
CI was ~85s, of which the install step alone was 53s.

Breakdown of that install from a baseline run:
- 39s — papi generating descriptors on postinstall
- 5s — downloading 762 packages
- 4s — supply-chain lockfile verification
- 4s — compile, nested install, git hooks

**Cache papi descriptors.** `.papi/descriptors` is generated output and gitignored, so every run rebuilt it from the .scale metadata. Restoring it before install lets papi skip codegen. papi validates restored descriptors against the codeHash in `polkadot-api.json` and regenerates on mismatch, so the `restore-keys` fallback is safe — a stale restore gets corrected, never used blindly.

**Reorder checks** so the fast ones fail first: biome → typecheck → knip → test → build.

**Modern actions**, which clears the "Node 20 is being deprecated" warning on every run: checkout v4 → v7, setup-node v4 → v7, pnpm/action-setup v4 → v6, plus cache v6.

Same caching and action bumps applied to fetch-tokens.yaml, which pays the identical 39s on every 6-hourly run.

### Measured on this PR

| | install | job |
|---|---|---|
| baseline (main) | 53s | 84s |
| run 1, cold cache | 66s | 132s |
| run 2, warm cache | **8s** | **53s** |

Run 2 logs confirm the mechanism: `Cache restored from key: papi-Linux-…` then `Detected previous descriptors with no changes needed`. No Node 20 deprecation warnings remain.

The first run after merge will be a cold miss while the cache is seeded on main; every run after that gets the 8s install.

Package download stays a miss on any dependency PR — setup-node's pnpm cache keys on the lockfile hash with no fallback. At 5s it wasn't worth replacing with a hand-rolled store cache.