### PR TITLE
🔒 patch js-yaml, nanoid, postcss and undici advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,10 @@ overrides:
   qs: ^6.15.2
   form-data: ^4.0.6
   ws@>=8.0.0 <8.21.0: ^8.21.0
-  undici: ^7.28.0
+  undici: ^7.29.0
+  js-yaml@4: ^4.3.1
+  nanoid@3: ^3.3.17
+  postcss: ^8.5.23
 
 importers:
 
@@ -3372,8 +3375,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -3662,8 +3665,8 @@ packages:
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3906,8 +3909,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.21:
-    resolution: {integrity: sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.24.2:
@@ -4437,8 +4440,8 @@ packages:
   undici-types@7.29.0:
     resolution: {integrity: sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -7867,7 +7870,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@7.0.2):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -8397,7 +8400,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -8418,7 +8421,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -8654,7 +8657,7 @@ snapshots:
 
   multiformats@9.9.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   no-case@3.0.4:
     dependencies:
@@ -9025,9 +9028,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.21:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9631,7 +9634,7 @@ snapshots:
   undici-types@7.29.0:
     optional: true
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -9777,7 +9780,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.21
+      postcss: 8.5.26
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,14 +23,6 @@ minimumReleaseAgeExclude:
   # willing to sit 3 days behind on papi releases.
   - "polkadot-api"
   - "@polkadot-api/*"
-  # TEMPORARY — GHSA-qwww-vcr4-c8h2 (high) is only patched in react-router 8.3.0, published
-  # 2026-07-22T15:04Z, i.e. inside the window. Remove on/after 2026-07-25T15:04Z, once the
-  # locked version has aged past minimumReleaseAge on its own.
-  - "react-router"
-  # TEMPORARY — 0.14.4 crashes the dev server on TypeScript 7 (upstream issue #777); the fix
-  # landed in 0.14.5, published 2026-07-22T10:07Z, i.e. inside the window. Remove on/after
-  # 2026-07-25T10:07Z, once the locked version has aged past minimumReleaseAge on its own.
-  - "vite-plugin-checker"
 
 # moved from package.json "pnpm" field (pnpm 11 no longer reads it, see https://pnpm.io/settings)
 overrides:
@@ -44,9 +36,19 @@ overrides:
   # memory disclosure. Pin all affected 8.x copies to >=8.21.0; ws@7 (walletconnect) is out
   # of range and left untouched.
   "ws@>=8.0.0 <8.21.0": "^8.21.0"
-  # GHSA: undici TLS cert-validation bypass (high) + cache disclosure (moderate), patched
-  # >=7.28.0. Dev-only copy via jsdom > vitest.
-  undici: "^7.28.0"
+  # GHSA-4cwx-7wf7-3272: undici cross-user cache disclosure + parse-time crash (high), plus
+  # four moderates (response desync, CRLF via blob type, two Cache-Control parsing issues).
+  # All patched >=7.29.0. Dev-only copy via jsdom > vitest.
+  undici: "^7.29.0"
+  # GHSA-5p4m-2wfm-xmqj: js-yaml quadratic CPU consumption in !!omap resolution (high),
+  # patched >=4.3.1. Dev-only copy via vite-plugin-svgr > @svgr/core > cosmiconfig.
+  "js-yaml@4": "^4.3.1"
+  # GHSA-2v37-7h3g-55p8: nanoid custom generators loop indefinitely on size 0 (high), patched
+  # >=3.3.17. Dev-only copy via vite > postcss. Scoped to 3.x so unrelated majors are untouched.
+  "nanoid@3": "^3.3.17"
+  # GHSA-fxqj-rqcc-2cmp: postcss reads arbitrary .map files via attacker-controlled
+  # sourceMappingURL when `from` is unset (moderate), patched >=8.5.23. Dev-only copy via vite.
+  postcss: "^8.5.23"
   # NOTE: esbuild GHSA-g7r4-m6w7-qqqr (low) — arbitrary file read via esbuild's OWN dev server
   # on Windows. Not applicable: this repo dev-serves through vite, not `esbuild serve`. esbuild
   # is a peer-only dep here (vite + rollup-plugin-esbuild peer onto it; no package declares it as


### PR DESCRIPTION
Adds overrides for 3 uncovered advisories (2 high, 1 moderate) and bumps the stale `undici` floor from 7.28.0 to 7.29.0 for 5 newer advisories.

Also drops the two expired `minimumReleaseAgeExclude` entries (react-router, vite-plugin-checker) — both target versions have aged past the window on their own.

`pnpm audit` goes from 3 high / 5 moderate / 2 low to 2 low (elliptic and esbuild, both already documented as unfixable/not-applicable).