### PR TITLE
⬆️ bump react-rx to 5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,8 +122,8 @@ importers:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-rx:
-        specifier: ^4.2.3
-        version: 4.2.3(react@19.2.8)(rxjs@7.8.2)
+        specifier: ^5.1.1
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       react-toastify:
         specifier: ^11.1.0
         version: 11.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3712,12 +3712,6 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
-  observable-callback@1.0.3:
-    resolution: {integrity: sha512-VlS275UyPnwdMtzxDgr/lCiOUyq9uXNll3vdwzDcJ6PB/LuO7gLmxAQopcCA3JoFwwujBwyA7/tP5TXZwWSXew==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      rxjs: ^6.5 || ^7
-
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -3963,11 +3957,6 @@ packages:
   randomfill@1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
-  react-compiler-runtime@1.0.0:
-    resolution: {integrity: sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
-
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
@@ -3986,11 +3975,12 @@ packages:
       react-dom:
         optional: true
 
-  react-rx@4.2.3:
-    resolution: {integrity: sha512-AzuecrOdmoIgVA/wYCCFUnWc1nFtu+6sd++uH03gYAHte/ujYApHPOPEgSlWbKDhMjiXrcYtzv9IJrxwtmurIw==}
+  react-rx@5.1.1:
+    resolution: {integrity: sha512-4GNme4kL2F825aNnsIDqrOSxK6j6tjkpVdbdeILS8WMWOpX1QFO/Wyb28WREYZmcXr9Vys4ZV7yDdw6k9OxuMQ==}
+    engines: {node: '>=22.12'}
     peerDependencies:
-      react: ^18.3 || >=19.0.0-0
-      rxjs: ^7
+      react: ^19.2
+      rxjs: ^7.2
 
   react-toastify@11.1.0:
     resolution: {integrity: sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==}
@@ -8699,10 +8689,6 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  observable-callback@1.0.3(rxjs@7.8.2):
-    dependencies:
-      rxjs: 7.8.2
-
   obug@2.1.4: {}
 
   ofetch@1.5.1:
@@ -9062,10 +9048,6 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
-  react-compiler-runtime@1.0.0(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -9080,11 +9062,9 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
-  react-rx@4.2.3(react@19.2.8)(rxjs@7.8.2):
+  react-rx@5.1.1(react@19.2.8)(rxjs@7.8.2):
     dependencies:
-      observable-callback: 1.0.3(rxjs@7.8.2)
       react: 19.2.8
-      react-compiler-runtime: 1.0.0(react@19.2.8)
       rxjs: 7.8.2
       use-effect-event: 2.0.3(react@19.2.8)
 

--- a/web/package.json
+++ b/web/package.json
@@ -40,7 +40,7 @@
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",
 		"react-router": "^8.3.0",
-		"react-rx": "^4.2.3",
+		"react-rx": "^5.1.1",
 		"react-toastify": "^11.1.0",
 		"rxjs": "^7.8.2",
 		"tailwind-merge": "^3.6.0",

--- a/web/src/hooks/useAllTokens.ts
+++ b/web/src/hooks/useAllTokens.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import type { TokenType } from "../registry/tokens/types";
 import { getAllTokens$ } from "../state/tokens";
 
@@ -12,5 +12,5 @@ const DEFAULT_VALUE = { isLoading: true, data: {} };
 export const useAllTokens = ({ types }: UseAllTokensProps) => {
 	const allTokens$ = useMemo(() => getAllTokens$(types), [types]);
 
-	return useObservable(allTokens$, DEFAULT_VALUE);
+	return useSyncObservable(allTokens$, DEFAULT_VALUE);
 };

--- a/web/src/hooks/useApi.ts
+++ b/web/src/hooks/useApi.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { catchError, map, of } from "rxjs";
 import { type Api, getApi$ } from "../papi/getApi";
 import type { ChainId } from "../registry/chains/types";
@@ -44,5 +44,5 @@ export const useApi = <Id extends ChainId>({
 		[chainId],
 	);
 
-	return useObservable(api$, defaultValue);
+	return useSyncObservable(api$, defaultValue);
 };

--- a/web/src/hooks/useAssetConvertPlancks.ts
+++ b/web/src/hooks/useAssetConvertPlancks.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { combineLatest, map, of, shareReplay, switchMap } from "rxjs";
 import type { TokenId } from "../registry/tokens/types";
 import { getTokenById$ } from "../services/tokens/service";
@@ -31,7 +31,7 @@ export const useAssetConvertPlancks = ({
 		[tokenIdIn, tokenIdOut, plancks],
 	);
 
-	return useObservable(obs, DEFAULT_VALUE_PLANCKS);
+	return useSyncObservable(obs, DEFAULT_VALUE_PLANCKS);
 };
 
 const DEFAULT_VALUE_PRICE = {
@@ -51,7 +51,7 @@ export const useAssetConvertPrice = ({
 		[tokenIdIn, tokenIdOut, plancks],
 	);
 
-	return useObservable(obs, DEFAULT_VALUE_PRICE);
+	return useSyncObservable(obs, DEFAULT_VALUE_PRICE);
 };
 
 const NO_TOKEN_RESULT = { token: null, status: "loaded" };

--- a/web/src/hooks/useBalances.ts
+++ b/web/src/hooks/useBalances.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map } from "rxjs";
 import { getBalances$ } from "../services/balances/service";
 import type { BalanceDef } from "../services/balances/types";
@@ -53,5 +53,5 @@ export const useBalances = ({
 		[balanceDefs],
 	);
 
-	return useObservable(balances$, defaultBalances);
+	return useSyncObservable(balances$, defaultBalances);
 };

--- a/web/src/hooks/useBalancesWithStables.ts
+++ b/web/src/hooks/useBalancesWithStables.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import {
 	combineLatest,
 	map,
@@ -76,5 +76,5 @@ export const useBalancesWithStables = ({
 		);
 	}, [accounts, tokens]);
 
-	return useObservable(obs, DEFAULT_VALUE);
+	return useSyncObservable(obs, DEFAULT_VALUE);
 };

--- a/web/src/hooks/useFeeTokens.ts
+++ b/web/src/hooks/useFeeTokens.ts
@@ -1,6 +1,6 @@
 import { isEqual, values } from "lodash-es";
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import {
 	distinctUntilChanged,
 	map,
@@ -41,7 +41,7 @@ export const useFeeTokens = ({
 		[chainId, address],
 	);
 
-	return useObservable(feeTokens$, DEFAULT_VALUES);
+	return useSyncObservable(feeTokens$, DEFAULT_VALUES);
 };
 
 const getFeeTokens$ = (

--- a/web/src/hooks/usePoolReserves.ts
+++ b/web/src/hooks/usePoolReserves.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map } from "rxjs";
 import { getAssetHubPoolReserves$ } from "../services/pools/reserves";
 import type { Pool } from "../services/pools/types";
@@ -19,5 +19,5 @@ export const usePoolReserves = ({ pool }: UsePoolReservesProps) => {
 		[pool],
 	);
 
-	return useObservable(obs, DEFAULT_VALUE);
+	return useSyncObservable(obs, DEFAULT_VALUE);
 };

--- a/web/src/hooks/usePoolReservesByTokenIds.ts
+++ b/web/src/hooks/usePoolReservesByTokenIds.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map } from "rxjs";
 import type { TokenId } from "../registry/tokens/types";
 import { getPoolReserves$ } from "../services/pools/reserves";
@@ -23,5 +23,5 @@ export const usePoolReservesByTokenIds = ({
 		[tokenId1, tokenId2],
 	);
 
-	return useObservable(obs, DEFAULT_VALUE);
+	return useSyncObservable(obs, DEFAULT_VALUE);
 };

--- a/web/src/hooks/usePoolSupplies.ts
+++ b/web/src/hooks/usePoolSupplies.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map } from "rxjs";
 import type { TokenIdsPair } from "../registry/tokens/types";
 import { getPoolSupplies$ } from "../services/poolSupplies/service";
@@ -41,5 +41,5 @@ export const usePoolSupplies = ({
 		[pairs],
 	);
 
-	return useObservable(poolSupplies$, defaultValue);
+	return useSyncObservable(poolSupplies$, defaultValue);
 };

--- a/web/src/hooks/usePoolsByChainId.ts
+++ b/web/src/hooks/usePoolsByChainId.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map } from "rxjs";
 import type { ChainId } from "../registry/chains/types";
 import { getPoolsByChain$ } from "../services/pools/service";
@@ -33,5 +33,5 @@ export const usePoolsByChainId = ({
 		[chainId],
 	);
 
-	return useObservable(pools$, defaultValue);
+	return useSyncObservable(pools$, defaultValue);
 };

--- a/web/src/hooks/useResolvedSubstrateAddress.ts
+++ b/web/src/hooks/useResolvedSubstrateAddress.ts
@@ -1,6 +1,6 @@
 import type { SS58String } from "polkadot-api";
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { catchError, map, of } from "rxjs";
 import type { ChainId } from "../registry/chains/types";
 import { getResolvedSubstrateAddress$ } from "../services/addressResolution/service";
@@ -56,7 +56,7 @@ export const useResolvedSubstrateAddress = ({
 		);
 	}, [address, chainId]);
 
-	return useObservable(obs, {
+	return useSyncObservable(obs, {
 		resolvedAddress: null,
 		isLoading: !!address && isEthereumAddress(address) && !!chainId,
 	});

--- a/web/src/hooks/useStablePlancksMulti.ts
+++ b/web/src/hooks/useStablePlancksMulti.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map, type Observable, switchMap } from "rxjs";
 import type { TokenId } from "../registry/tokens/types";
 import { getAssetConvertMulti$ } from "../state/convert";
@@ -44,5 +44,5 @@ export const useStablePlancksMulti = ({
 }: UseStablePlancksProps): UseStablePlancksResult => {
 	const obs = useMemo(() => getStablePlancksMulti$(inputs), [inputs]);
 
-	return useObservable(obs, DEFAULT_VALUE);
+	return useSyncObservable(obs, DEFAULT_VALUE);
 };

--- a/web/src/hooks/useToken.ts
+++ b/web/src/hooks/useToken.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map, of } from "rxjs";
 import type { Token, TokenId } from "../registry/tokens/types";
 import { getTokenById$ } from "../services/tokens/service";
@@ -35,5 +35,5 @@ export const useToken = ({ tokenId }: UseTokenProps): UseTokenResult => {
 		[tokenId],
 	);
 
-	return useObservable(token$, defaultValue);
+	return useSyncObservable(token$, defaultValue);
 };

--- a/web/src/hooks/useTokenInfos.ts
+++ b/web/src/hooks/useTokenInfos.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map } from "rxjs";
 import type { TokenId, TokenInfo } from "../registry/tokens/types";
 import { getTokenInfos$ } from "../services/tokenInfos/service";
@@ -46,5 +46,5 @@ export const useTokenInfos = ({
 		[tokenIds],
 	);
 
-	return useObservable(tokenInfos$, defaultResult);
+	return useSyncObservable(tokenInfos$, defaultResult);
 };

--- a/web/src/hooks/useTokenPrices.ts
+++ b/web/src/hooks/useTokenPrices.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { getTokenPrices$ } from "../state/prices";
 
 const DEFAULT_VALUE = { data: [], isLoading: true };
@@ -8,5 +8,5 @@ const DEFAULT_VALUE = { data: [], isLoading: true };
 export const useTokenPrices = () => {
 	const tokenPrices$ = useMemo(() => getTokenPrices$(), []);
 
-	return useObservable(tokenPrices$, DEFAULT_VALUE);
+	return useSyncObservable(tokenPrices$, DEFAULT_VALUE);
 };

--- a/web/src/hooks/useTokensByChainIds.ts
+++ b/web/src/hooks/useTokensByChainIds.ts
@@ -1,6 +1,6 @@
 import { values } from "lodash-es";
 import { useMemo } from "react";
-import { useObservable } from "react-rx";
+import { useSyncObservable } from "react-rx";
 import { map } from "rxjs";
 import type { ChainId } from "../registry/chains/types";
 import type { Token } from "../registry/tokens/types";
@@ -44,5 +44,5 @@ export const useTokensByChainIds = ({
 		[chainIds],
 	);
 
-	return useObservable(tokens$, defaultValue);
+	return useSyncObservable(tokens$, defaultValue);
 };


### PR DESCRIPTION
Stacked on #93.

v5 makes `useObservable` defer store updates through `useDeferredValue`, so urgent renders keep the previous value. Every call site here feeds swap amounts, balances or prices, where a stale value during an urgent render would be wrong.

Renamed all 17 call sites to `useSyncObservable`, the v5 export that keeps v4's synchronous behaviour. Behaviour is unchanged; opting individual hooks into the deferred variant can be evaluated later.

Migration guide: https://react-rx.dev/migrate/v4-to-v5