### PR TITLE
🚑 replace dead IBP/dotters RPC endpoints

### DIFF
--- a/web/src/common/kheopskit.ts
+++ b/web/src/common/kheopskit.ts
@@ -102,8 +102,8 @@ const paseoAssetHub = defineSubstrateNetwork({
 	name: "Paseo Asset Hub",
 	symbol: "PAS",
 	decimals: 10,
-	http: ["https://sys.ibp.network/asset-hub-paseo"],
-	webSocket: ["wss://sys.ibp.network/asset-hub-paseo"],
+	http: ["https://sys.turboflakes.io/asset-hub-paseo"],
+	webSocket: ["wss://sys.turboflakes.io/asset-hub-paseo"],
 });
 
 const polkadotAssetHubEvm = defineEthereumNetwork({

--- a/web/src/registry/chains/chains.prod.json
+++ b/web/src/registry/chains/chains.prod.json
@@ -4,10 +4,11 @@
 		"name": "Polkadot Asset Hub",
 		"wsUrl": [
 			"wss://rpc-asset-hub-polkadot.luckyfriday.io",
-			"wss://sys.ibp.network/asset-hub-polkadot",
-			"wss://asset-hub-polkadot.dotters.network",
 			"wss://polkadot-asset-hub-rpc.polkadot.io",
-			"wss://dot-rpc.stakeworld.io/assethub"
+			"wss://dot-rpc.stakeworld.io/assethub",
+			"wss://asset-hub-polkadot-rpc.n.dwellir.com",
+			"wss://sys.turboflakes.io/asset-hub-polkadot",
+			"wss://asset-hub-polkadot.rpc.amforc.com"
 		],
 		"evmChainId": 420420419,
 		"evmRpcUrl": ["https://eth-rpc.polkadot.io"],
@@ -22,11 +23,12 @@
 		"id": "kah",
 		"name": "Kusama Asset Hub",
 		"wsUrl": [
-			"wss://sys.ibp.network/statemine",
-			"wss://kusama-asset-hub-rpc.polkadot.io",
-			"wss://sys.dotters.network/statemine",
 			"wss://rpc-asset-hub-kusama.luckyfriday.io",
-			"wss://ksm-rpc.stakeworld.io/assethub"
+			"wss://kusama-asset-hub-rpc.polkadot.io",
+			"wss://ksm-rpc.stakeworld.io/assethub",
+			"wss://asset-hub-kusama-rpc.n.dwellir.com",
+			"wss://sys.turboflakes.io/asset-hub-kusama",
+			"wss://asset-hub-kusama.rpc.amforc.com"
 		],
 		"evmChainId": 420420418,
 		"evmRpcUrl": ["https://kusama-asset-hub-eth-rpc.polkadot.io"],
@@ -43,9 +45,9 @@
 		"id": "wah",
 		"name": "Westend Asset Hub",
 		"wsUrl": [
-			"wss://sys.ibp.network/westmint",
-			"wss://sys.dotters.network/westmint",
-			"wss://westend-asset-hub-rpc.polkadot.io"
+			"wss://westend-asset-hub-rpc.polkadot.io",
+			"wss://asset-hub-westend-rpc.n.dwellir.com",
+			"wss://sys.turboflakes.io/asset-hub-westend"
 		],
 		"evmChainId": 420420421,
 		"evmRpcUrl": ["https://westend-asset-hub-eth-rpc.polkadot.io"],
@@ -62,9 +64,8 @@
 		"id": "pasah",
 		"name": "Paseo Asset Hub",
 		"wsUrl": [
-			"wss://sys.ibp.network/asset-hub-paseo",
-			"wss://asset-hub-paseo.dotters.network",
-			"wss://sys.turboflakes.io/asset-hub-paseo"
+			"wss://sys.turboflakes.io/asset-hub-paseo",
+			"wss://asset-hub-paseo-rpc.n.dwellir.com"
 		],
 		"evmChainId": 420420417,
 		"evmRpcUrl": ["https://eth-rpc-testnet.polkadot.io"],


### PR DESCRIPTION
All `sys.ibp.network/*` and `*.dotters.network` asset-hub endpoints are down (verified sequentially, both legacy `statemine`/`westmint` and current path names). Chaindata v13 dropped them too.

Left `wah` and `pasah` running on a single live RPC each.

| chain | live before | after |
|---|---|---|
| pah | 3/5 | 6/6 |
| kah | 3/5 | 6/6 |
| wah | 1/3 | 3/3 |
| pasah | 1/3 | 2/2 |

Also fixes the Paseo AH WalletConnect network in `kheopskit.ts`, which pointed at the dead IBP endpoint for both http and ws.

Replacements taken from chaindata v13, except:
- excluded `wss://pas-rpc.stakeworld.io/assethub` — chaindata lists it as Paseo AH's only RPC but it serves **Polkadot** AH (chaindata's `paseo-asset-hub` genesisHash is polluted with Polkadot's as a result)
- added amforc (pah/kah) + turboflakes (wah), live but absent from chaindata
- skipped onfinality `public-ws` (rate limits)

All 17 endpoints verified live and on the correct chain.